### PR TITLE
PR for #4: Introduce support for workspaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ jenkins_jobs:
     state: present
     # Weather you want to update the file after the initial copy or not.
     update: yes
+    # If a workspace is needed for the job, we can specify a git path.
+    workspace_git: git@github.org/user/repo.git
     # An index of all the files you need managed.
     files:
       - config.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -94,3 +94,49 @@
     - item.state is defined
     - item.state == "present"
     - item.update
+
+- name: Jenkins Jobs | Create directories for workspaces
+  file:
+    path: "{{ jenkins_directory }}/workspace"
+    state: directory
+    mode: 0755
+    owner: "{{ jenkins_job_owner }}"
+    group: "{{ jenkins_job_group }}"
+
+- name: Jenkins Jobs | Clone workspaces as current user
+  git:
+    repo: "{{ item.workspace_git }}"
+    dest: "{{ jenkins_directory }}/workspace/{{ item.name }}"
+    clone: yes
+    update: yes
+    force: no
+    accept_hostkey: yes
+  with_items:
+    - "{{ jenkins_jobs }}"
+  when:
+    - item.name is defined
+    - item.workspace_git is defined
+    - item.state is defined
+    - item.state == "present"
+    - jenkins_clone_user is not defined
+    - item.update
+
+- name: Jenkins Jobs | Clone workspaces as configured user
+  become: no
+  become_user: "{{ jenkins_clone_user }}"
+  git:
+    repo: "{{ item.workspace_git }}"
+    dest: "{{ jenkins_directory }}/workspace/{{ item.name }}"
+    clone: yes
+    update: yes
+    force: no
+    accept_hostkey: yes
+  with_items:
+    - "{{ jenkins_jobs }}"
+  when:
+    - item.name is defined
+    - item.workspace_git is defined
+    - item.state is defined
+    - item.state == "present"
+    - jenkins_clone_user is defined
+    - item.update

--- a/tests/playbook.yml
+++ b/tests/playbook.yml
@@ -10,6 +10,7 @@
       - name: Deploy Test Application
         folder: deploy-test-app
         state: present
+        workspace_git: https://github.com/mulesoft-labs/jenkins-job-examples.git
         files:
           - config.xml
     jenkins_config_files: []


### PR DESCRIPTION
This PR resolves #4.

Adds support for git workspaces, which is primitive (for now), but can be improved later if needed.

It will clone a repository to the respective folder for the job to be run.